### PR TITLE
feat: export sdk snippets

### DIFF
--- a/liblab.config.json
+++ b/liblab.config.json
@@ -4,6 +4,7 @@
   "apiName": "magicbell-api",
   "languages": ["go"],
   "auth": ["bearer"],
+  "docs": ["snippets"],
   "customizations": {
     "devContainer": false,
     "generateEnv": false,
@@ -23,6 +24,11 @@
       "enabled": true,
       "maxAttempts": 3,
       "retryDelay": 150
+    },
+    "documentation": {
+      "snippets": {
+        "format": "json"
+      }
     }
   },
   "languageOptions": {

--- a/scripts/liblab-docs.ts
+++ b/scripts/liblab-docs.ts
@@ -26,3 +26,6 @@ md.mapLinks(readmeAst, rewriteHref);
 md.insertFrontMatter(readmeAst, { title: pkg.docs?.name || pkg.name });
 
 await md.write(readmeAst, path.join(outdir, 'index.mdx'));
+
+// copy snippets
+await fs.copyFile(path.join(root, 'documentation/snippets/snippets.json'), path.join(outdir, 'snippets.json'));


### PR DESCRIPTION
Include `snippets.json` in documentation assets